### PR TITLE
Fixed the typo of an application property.

### DIFF
--- a/section9/gatewayserver/src/main/resources/application.yml
+++ b/section9/gatewayserver/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     gateway:
       discovery:
         locator:
-          enabled: false
+          enabled: true
           lowerCaseServiceId: true
 
 management:


### PR DESCRIPTION
```
  cloud:
    gateway:
      discovery:
        locator:
          enabled: false
```
Should be `true`.