### PR TITLE
Added a comment for the api gateway endpoint change.

### DIFF
--- a/section9/gatewayserver/src/main/resources/application.yml
+++ b/section9/gatewayserver/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     gateway:
       discovery:
         locator:
+          # should be true with default gateway paths
           enabled: false
           lowerCaseServiceId: true
 


### PR DESCRIPTION
Turns out they are disabled when we created custom endpoint. However, this did confused me when I copied the code during lecture 122. Took me a while to find this minor discrepancy. So I suggest adding a comment for this property.